### PR TITLE
Update to Berkshelf 3

### DIFF
--- a/wercker-box.yml
+++ b/wercker-box.yml
@@ -1,12 +1,12 @@
-name: ubuntu12.04-ruby1.9.3-berkshelf1
+name: ubuntu12.04-ruby1.9.3-berkshelf3
 version: 0.0.4
 description: Box for installing chef recipes using berkshelf
 type : main
 platform : ubuntu@12.04
 packages :
   - ruby@1.9.3
-  - berkshelf@1.1.6
+  - berkshelf@3.2.3
 script : |
   sudo apt-get update
   sudo apt-get install ruby1.9.3 curl git build-essential
-  sudo gem install berkshelf -v '1.1.6' --no-rdoc --no-ri
+  sudo gem install berkshelf -v '3.2.3' --no-rdoc --no-ri


### PR DESCRIPTION
Wercker doesn't have a service box for Postgres 9.3, only 9.2, which doesn't have JSON support. Forked the wercker box repo to updated it, but it relies on Berkshelf v1 and wasn't able to get all the cookbooks needed to build. Got tired of waiting for the berkshelf overrided in the postgres box to rebuild when testing that box, so forked the berkshelf box here to update to v3.

Tested and validated, will merge TBR.